### PR TITLE
12.0 customer product code ehe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/ifscg_stock/__init__.py
+++ b/ifscg_stock/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+

--- a/ifscg_stock/__manifest__.py
+++ b/ifscg_stock/__manifest__.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'IFSCG: Customer Product Code',
+    'summary': 'Customer Product Code',
+    'sequence': 100,
+    'license': 'OEEL-1',
+    'website': 'https://www.odoo.com',
+    'version': '2.0',
+    'author': 'Odoo Inc',
+    'description': """
+Various customers call the same product differently.
+Let's the product ITALIAN STYLE MEATBALLS 1 OZ MAC has Internal reference as 001
+Customer A has an internal reference 20265
+Customer B has an internal reference 20001
+So in the SO to Customer A, when we select the product "ABC123", it should auto-populate the internal reference as 20265.
+If customer C buys this product it will have internal reference 001.
+In the database create a Model called Customer Product Code. This model will have the following fields - Customer Product Code, product name and Customer.
+When I create the Invoice and Delivery Order, this reference should pass on to the invoice and Delivery Order Form with the new reference number.
+    """,
+    'category': 'Custom Development',
+    'depends': ['sale_management', 'delivery', 'sale_stock'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/customer_product_code.xml',
+        'views/product_views.xml',
+        'views/sale_order_views.xml',
+        'views/account_invoice.xml',
+        'views/stock_picking.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/ifscg_stock/models/__init__.py
+++ b/ifscg_stock/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import product
+from . import sale_order
+from . import account_invoice
+from . import stock_move

--- a/ifscg_stock/models/account_invoice.py
+++ b/ifscg_stock/models/account_invoice.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.onchange('partner_id')
+    def _onchange_partner_id(self):
+        super(AccountInvoice, self)._onchange_partner_id()
+        if self.partner_id and self.invoice_line_ids:
+            self.invoice_line_ids._onchange_product_id_for_customer_product_code()
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = 'account.invoice.line'
+
+    customer_product_code = fields.Char('Customer Product Code')
+
+    @api.onchange('product_id', 'invoice_id')
+    def _onchange_product_id_for_customer_product_code(self):
+        for line in self:
+            if line.product_id and line.invoice_id.partner_id:
+                customer_product_code_ids = self.env['customer.product.code'].search([('product_id', '=', line.product_id.id), ('partner_id', '=', line.invoice_id.partner_id.id)])
+                if customer_product_code_ids:
+                    line.customer_product_code = customer_product_code_ids[0].name
+                else:
+                    line.customer_product_code = line.product_id.default_code
+
+

--- a/ifscg_stock/models/product.py
+++ b/ifscg_stock/models/product.py
@@ -8,9 +8,9 @@ class CustomerProductCode(models.Model):
     _name = 'customer.product.code'
     _description = 'Customer Product Code'
 
-    name = fields.Char('Customer Product Code')
-    product_id = fields.Many2one('product.product', ondelete='set null', string='Product')
-    partner_id = fields.Many2one('res.partner', ondelete='set null', string='Customer')
+    name = fields.Char('Customer Product Code', required=True)
+    product_id = fields.Many2one('product.product', ondelete='set null', string='Product', required=True)
+    partner_id = fields.Many2one('res.partner', ondelete='set null', string='Customer', required=True)
 
     _sql_constraints = [
         ('alias_uniq', 'UNIQUE(product_id, partner_id)',  _('Cannot create multiple alias for the same customer and the same product.')),

--- a/ifscg_stock/models/product.py
+++ b/ifscg_stock/models/product.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, api, _
+
+
+class CustomerProductCode(models.Model):
+    _name = 'customer.product.code'
+    _description = 'Customer Product Code'
+
+    name = fields.Char('Customer Product Code')
+    product_id = fields.Many2one('product.product', ondelete='set null', string='Product')
+    partner_id = fields.Many2one('res.partner', ondelete='set null', string='Customer')
+
+    _sql_constraints = [
+        ('alias_uniq', 'UNIQUE(product_id, partner_id)',  _('Cannot create multiple alias for the same customer and the same product.')),
+    ]
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    customer_product_code_ids = fields.One2many('customer.product.code', 'product_id', string='Customer Product Code')

--- a/ifscg_stock/models/sale_order.py
+++ b/ifscg_stock/models/sale_order.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        super(SaleOrder, self).onchange_partner_id()
+        if self.partner_id and self.order_line:
+            self.order_line._onchange_product_id_for_customer_product_code()
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    customer_product_code = fields.Char('Customer Product Code')
+
+    @api.onchange('product_id', 'order_id')
+    def _onchange_product_id_for_customer_product_code(self):
+        for line in self:
+            if line.product_id and line.order_id.partner_id:
+                customer_product_code_ids = self.env['customer.product.code'].search([('product_id', '=', line.product_id.id), ('partner_id', '=', line.order_id.partner_id.id)])
+                if customer_product_code_ids:
+                    line.customer_product_code = customer_product_code_ids[0].name
+                else:
+                    line.customer_product_code = line.product_id.default_code
+
+    @api.multi
+    def _prepare_invoice_line(self, qty):
+        res = super(SaleOrderLine, self)._prepare_invoice_line(qty)
+        res.update({
+            'customer_product_code': self.customer_product_code,
+        })
+        return res
+
+
+    @api.multi
+    def _prepare_procurement_values(self, group_id=False):
+
+        values = super(SaleOrderLine, self)._prepare_procurement_values(group_id)
+        values.update({
+            'customer_product_code': self.customer_product_code,
+        })
+        return values
+
+
+

--- a/ifscg_stock/models/sale_order.py
+++ b/ifscg_stock/models/sale_order.py
@@ -17,33 +17,39 @@ class SaleOrder(models.Model):
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-    customer_product_code = fields.Char('Customer Product Code')
+    customer_product_id = fields.Many2one('customer.product.code', ondelete='set null', string='Customer Product Code')
+    customer_product_code = fields.Char('Customer Product Code (Code)', related='customer_product_id.name')
 
     @api.onchange('product_id', 'order_id')
     def _onchange_product_id_for_customer_product_code(self):
         for line in self:
-            if line.product_id and line.order_id.partner_id:
+            if line.product_id and line.order_id.partner_id and line.customer_product_id.product_id != line.product_id:
                 customer_product_code_ids = self.env['customer.product.code'].search([('product_id', '=', line.product_id.id), ('partner_id', '=', line.order_id.partner_id.id)])
                 if customer_product_code_ids:
-                    line.customer_product_code = customer_product_code_ids[0].name
+                    line.customer_product_id = customer_product_code_ids[0]
                 else:
-                    line.customer_product_code = line.product_id.default_code
+                    line.customer_product_id = False
+
+    @api.onchange('customer_product_id')
+    def _onchange_customer_product_id(self):
+        for line in self:
+            if line.customer_product_id and line.order_id.partner_id and line.customer_product_id.product_id != line.product_id:
+                line.product_id = line.customer_product_id.product_id
 
     @api.multi
     def _prepare_invoice_line(self, qty):
         res = super(SaleOrderLine, self)._prepare_invoice_line(qty)
         res.update({
-            'customer_product_code': self.customer_product_code,
+            'customer_product_code': self.customer_product_code or self.product_id.default_code,
         })
         return res
-
 
     @api.multi
     def _prepare_procurement_values(self, group_id=False):
 
         values = super(SaleOrderLine, self)._prepare_procurement_values(group_id)
         values.update({
-            'customer_product_code': self.customer_product_code,
+            'customer_product_code': self.customer_product_code or self.product_id.default_code,
         })
         return values
 

--- a/ifscg_stock/models/stock_move.py
+++ b/ifscg_stock/models/stock_move.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _get_stock_move_values(self, product_id, product_qty, product_uom, location_id, name, origin, values, group_id):
+
+        move_values = super(StockRule, self)._get_stock_move_values(product_id, product_qty, product_uom, location_id, name, origin, values, group_id)
+        move_values.update({
+            'customer_product_code': values.get('customer_product_code')
+        })
+
+        return move_values
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.onchange('picking_type_id', 'partner_id')
+    def onchange_picking_type(self):
+        super(StockPicking, self).onchange_picking_type()
+        if self.partner_id and self.move_ids_without_package:
+            self.move_ids_without_package._onchange_product_id_for_customer_product_code()
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    customer_product_code = fields.Char('Customer Product Code')
+
+    @api.onchange('product_id', 'picking_id')
+    def _onchange_product_id_for_customer_product_code(self):
+        for move in self:
+            if move.product_id and move.picking_id and move.picking_id.partner_id:
+
+                customer_product_code_ids = self.env['customer.product.code'].search(
+                    [('product_id', '=', move.product_id.id), ('partner_id', '=', move.picking_id.partner_id.id)])
+                if customer_product_code_ids:
+                    move.customer_product_code = customer_product_code_ids[0].name
+                else:
+                    move.customer_product_code = move.product_id.default_code
+
+
+class StockMoveLine(models.Model):
+    _inherit = 'stock.move.line'
+
+    customer_product_code = fields.Char(related='move_id.customer_product_code')

--- a/ifscg_stock/security/ir.model.access.csv
+++ b/ifscg_stock/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_customer_product_code,access_customer_product_code,ifscg_stock.model_customer_product_code,,1,1,1,0

--- a/ifscg_stock/security/ir.model.access.csv
+++ b/ifscg_stock/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_customer_product_code,access_customer_product_code,ifscg_stock.model_customer_product_code,,1,1,1,0
+access_customer_product_code_system,access_customer_product_code_system,ifscg_stock.model_customer_product_code,base.group_system,1,1,1,1

--- a/ifscg_stock/views/account_invoice.xml
+++ b/ifscg_stock/views/account_invoice.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <record id="view_account_invoice_form_inheritifscg" model="ir.ui.view">
+            <field name="name">account_invoice_form_inherit_ifscg</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//form[1]/sheet[1]/notebook[1]/page[1]/field[@name='invoice_line_ids']/tree[1]/field[@name='product_id']" position="after">
+                    <field name="customer_product_code"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>
+

--- a/ifscg_stock/views/customer_product_code.xml
+++ b/ifscg_stock/views/customer_product_code.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <record id="view_customer_product_code_tree" model="ir.ui.view">
+            <field name="name">Customer Product Code Tree View</field>
+            <field name="model">customer.product.code</field>
+            <field name="priority">16</field>
+            <field name="arch" type="xml">
+                <tree string="Customer Product Code" create="1" edit="1" import="1">
+                    <field name="name"/>
+                    <field name="product_id"/>
+                    <field name="partner_id"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_customer_product_code_form" model="ir.ui.view">
+            <field name="name">Customer Product Code Form View</field>
+            <field name="model">customer.product.code</field>
+            <field name="priority">16</field>
+            <field name="arch" type="xml">
+                <form string="Customer Product Code" create="1" edit="1" import="1">
+                    <group>
+                        <group>
+                            <field name="product_id" required="1"/>
+                            <field name="partner_id" required="1"/>
+                        </group>
+                        <group>
+                            <field name="name" required="1"/>
+                        </group>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_customer_product_code" model="ir.actions.act_window">
+            <field name="name">Customer Product Code Action</field>
+            <field name="res_model">customer.product.code</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{}</field>
+        </record>
+
+        <menuitem id="menu_customer_product_code" name="Customer Product Code" action="action_customer_product_code" parent="stock.menu_stock_inventory_control" sequence="25"/>
+    </data>
+</odoo>

--- a/ifscg_stock/views/product_views.xml
+++ b/ifscg_stock/views/product_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_product_product_normal_form_inherit_ifscg" model="ir.ui.view">
+        <field name="name">product_product_normal_form_inherit_ifscg</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+          <xpath expr="//form[1]/sheet[1]/notebook[1]" position="inside">
+            <page name="customer_product_code" string="Customer Product Code">
+              <field name="customer_product_code_ids" mode="tree,form" context="{'default_product_id': active_id}">
+                    <tree editable="bottom" create="1">
+                        <field name="partner_id"/>
+                        <field name="name"/>
+                    </tree>
+                </field>
+            </page>
+          </xpath>
+        </field>
+    </record>
+
+
+
+</odoo>

--- a/ifscg_stock/views/sale_order_views.xml
+++ b/ifscg_stock/views/sale_order_views.xml
@@ -7,10 +7,22 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='order_line']//form//field[@name='product_id']" position="after">
-                <field name="customer_product_code"/>
+                <field name="customer_product_id" context="{'default_partner_id': parent.partner_id, 'default_product_id': product_id}" domain="[('partner_id', '=', parent.partner_id)]" options="{'no_create_edit': 1}">
+<!--                    <form>-->
+<!--                        <field name="product_id"/>-->
+<!--                        <field name="partner_id" readonly="1"/>-->
+<!--                        <field name="name"/>-->
+<!--                    </form>-->
+                </field>
             </xpath>
             <xpath expr="//field[@name='order_line']//tree//field[@name='product_id']" position="after">
-                <field name="customer_product_code"/>
+                <field name="customer_product_id" context="{'default_partner_id': parent.partner_id, 'default_product_id': product_id}" domain="[('partner_id', '=', parent.partner_id)]" options="{'no_create_edit': 1}">
+<!--                    <form>-->
+<!--                        <field name="product_id"/>-->
+<!--                        <field name="partner_id" readonly="1"/>-->
+<!--                        <field name="name"/>-->
+<!--                    </form>-->
+                </field>
             </xpath>
 
         </field>

--- a/ifscg_stock/views/sale_order_views.xml
+++ b/ifscg_stock/views/sale_order_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form_inherit_ifscg" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.ifscg</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']//form//field[@name='product_id']" position="after">
+                <field name="customer_product_code"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree//field[@name='product_id']" position="after">
+                <field name="customer_product_code"/>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/ifscg_stock/views/stock_picking.xml
+++ b/ifscg_stock/views/stock_picking.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <record id="view_stock_view_picking_form_inherit_ifscg" model="ir.ui.view">
+            <field name="name">stock_view_picking_form_inherit_ifscg</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.view_picking_form"/>
+            <field name="arch" type="xml">
+              <xpath expr="//field[@name='move_ids_without_package']/tree[1]/field[@name='product_id']" position="after">
+                <field name="customer_product_code"/>
+              </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>
+


### PR DESCRIPTION
Task ID =1981671
demo: https://youtu.be/ob7-iFyOHWU

1. Original Spec:

Various customers call the same product differently.
Let's the product ITALIAN STYLE MEATBALLS 1 OZ MAC has Internal reference as 001
Customer A has an internal reference 20265
Customer B has an internal reference 20001

So in the SO to Customer A, when we select the product "ABC123", it should auto-populate the internal reference as 20265.
If customer C buys this product it will have internal reference 001.

In the database create a Model called Customer Product Code. This model will have the following fields - Customer Product Code, product name and Customer.

When I create the Invoice and Delivery Order, this reference should pass on to the invoice and Delivery Order Form with the new reference number.

2. Added 3 hours MRR on the original spec for the following added scenarios:

There is product A that has internal reference [PA001], currently with no Customer Product Code defined.
Now we create a Sale Order to customer A.

Scenario 1)
If the user search on product first and choose product A, they will have all the default fields populated, but Customer Product Code will be empty. 
When they create invoice and delivery, those documents will populate the Customer Product Code using the internal reference 'PA001'.

Scenario 2)
If the user search on Customer Product Code and hit create, and there they create a customer.product.code record with product A and code 'CUSTOMERCODEA'. 
Then after creating Customer Product Code, the SOL will try to pull that product and auto populate the default fields. 
When they create invoice and delivery, those documents will populate the Customer Product Code using 'CUSTOMERCODEA'.

Scenario 3)
When there are existing Customer Product Code for products, then select either of them will auto populate the other.
