### PR TITLE
[ADD][1959395] IFSCG: Calculated Ordered Qty

### DIFF
--- a/ifscg_sale/__init__.py
+++ b/ifscg_sale/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/ifscg_sale/__manifest__.py
+++ b/ifscg_sale/__manifest__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'IFSCG Sale',
+    'category': 'Custom Development',
+    'sequence': 60,
+    'summary': 'IFSCG Calculate Qty on Sale',
+    'license': 'OEEL-1',
+    'website': 'https://www.odoo.com',
+    'depends': ['sale_management', 'purchase', 'account', 'stock'],
+    'version': '1.0',
+    'description': """
+IFSCG Calculate Qty
+===================
+* [#1959395]
+
+* Req 1:
+    - Create a new field "Weight for SO" on the product. (Default this to 1)
+    -  Add a new column called cases on the SO Line.
+    - Ordered qty will be calculated by the formula (case * weight for SO)
+    - The SO line will have the new column and Ordered qty will be calculated based on that -
+    - Since Case is 5, this gets multiplied by the weight which gets the ordered qty to 108.1.
+    - If someone modifies the ordered qty,
+    - give a pop-up warning saying that "Adjust case qty as per ordered qty"
+
+* Req 2:
+    - Add a calculated field called "Volume" on the Invoice Form and PO Form.
+    - Volume = Case (filed on invoice and PO) * volume (field on the product)
+""",
+    'data': [
+
+        # views
+        'data/data.xml',
+        'views/product_views.xml',
+        'views/sale_views.xml',
+        'views/purchase_views.xml',
+        'views/invoice_views.xml',
+
+    ],
+    'test': [
+    ],
+    'demo': [
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/ifscg_sale/data/data.xml
+++ b/ifscg_sale/data/data.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+       <record id="product_uom_case" model="uom.uom">
+            <field name="name">Case</field>
+            <field name="factor">1000</field>
+            <field name="category_id" ref="uom.product_uom_categ_unit"/>
+            <field name="uom_type">smaller</field>
+        </record>
+        <record id="product_uom_pound" model="uom.uom">
+            <field name="name">pound</field>
+            <field name="category_id" ref="uom.product_uom_categ_kgm"/>
+            <field name="factor">1000</field>
+            <field name="uom_type">smaller</field>
+        </record>
+    </data>
+</odoo>

--- a/ifscg_sale/models/__init__.py
+++ b/ifscg_sale/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+from . import product
+from . import purchase
+from . import sale
+from . import invoice

--- a/ifscg_sale/models/invoice.py
+++ b/ifscg_sale/models/invoice.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = "account.invoice.line"
+
+    volume = fields.Float(string="Volume", compute="_compute_volume", store=True)
+    case = fields.Float(string="Cases")
+
+    @api.onchange('case', 'product_id')
+    def onchange_case(self):
+        self.quantity = self.case * self.product_id.weight_for_so
+        # product_uom_case = self.env.ref('ifscg_sale.product_uom_case').id
+        # product_uom_pound = self.env.ref('ifscg_sale.product_uom_pound').id
+        # self.uom_id = self.product_id.weight_for_so > 1 and product_uom_pound or product_uom_case
+
+    @api.one
+    @api.constrains('case', 'quantity')
+    def validate_ordered_qty(self):
+        quantity = self.case * self.product_id.weight_for_so
+        if self.case > 0 and self.quantity != quantity:
+            raise ValidationError(_('The calculated ordered quantity has been modified, if you need to recalculate the ordered quantity then you have to modify the Cases value'))
+
+    @api.depends('case', 'product_id', 'product_id.volume')
+    def _compute_volume(self):
+        for rec in self:
+            rec.volume = rec.case * rec.product_id.volume
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    def _prepare_invoice_line_from_po_line(self, line):
+        data = super(AccountInvoice, self)._prepare_invoice_line_from_po_line(line)
+        data['case'] = line.case
+        data['volume'] = line.volume
+        return data

--- a/ifscg_sale/models/product.py
+++ b/ifscg_sale/models/product.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+import odoo.addons.decimal_precision as dp
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    weight_for_so = fields.Float(
+        'Weight For So', compute='_compute_weight_for_so', digits=dp.get_precision('Stock Weight'),
+        inverse='_set_weight_for_so', store=True, default=1)
+
+    @api.one
+    def _set_weight_for_so(self):
+        if len(self.product_variant_ids) == 1:
+            self.product_variant_ids.weight_for_so = self.weight_for_so
+
+    @api.depends('product_variant_ids', 'product_variant_ids.weight_for_so')
+    def _compute_weight_for_so(self):
+        unique_variants = self.filtered(lambda template: len(template.product_variant_ids) == 1)
+        for template in unique_variants:
+            template.weight_for_so = template.product_variant_ids.weight_for_so
+        for template in (self - unique_variants):
+            template.weight_for_so = 1
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    weight_for_so = fields.Float(string="Weight For So", digits=dp.get_precision('Stock Weight'), default=1)

--- a/ifscg_sale/models/purchase.py
+++ b/ifscg_sale/models/purchase.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    volume = fields.Float(string="Volume", compute="_compute_volume", store=True)
+    case = fields.Float(string="Cases")
+
+    @api.onchange('case', 'product_id')
+    def onchange_case(self):
+        self.product_qty = self.case * self.product_id.weight_for_so
+        # product_uom_case = self.env.ref('ifscg_sale.product_uom_case').id
+        # product_uom_pound = self.env.ref('ifscg_sale.product_uom_pound').id
+        # self.product_uom = self.product_id.weight_for_so > 1 and product_uom_pound or product_uom_case
+
+    @api.one
+    @api.constrains('case', 'product_qty')
+    def validate_ordered_qty(self):
+        product_qty = self.case * self.product_id.weight_for_so
+        if self.case > 0 and self.product_qty != product_qty:
+            raise ValidationError(_('The calculated ordered quantity has been modified, if you need to recalculate the ordered quantity then you have to modify the Cases value'))
+
+    @api.depends('case', 'product_id', 'product_id.volume')
+    def _compute_volume(self):
+        for rec in self:
+            rec.volume = rec.case * rec.product_id.volume

--- a/ifscg_sale/models/sale.py
+++ b/ifscg_sale/models/sale.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    volume = fields.Float(string="Volume", compute="_compute_volume", store=True)
+    case = fields.Float(string="Cases")
+
+    @api.onchange('case', 'product_id')
+    def onchange_case(self):
+        self.product_uom_qty = self.case * self.product_id.weight_for_so
+        # product_uom_case = self.env.ref('ifscg_sale.product_uom_case').id
+        # product_uom_pound = self.env.ref('ifscg_sale.product_uom_pound').id
+        # self.product_uom = self.product_id.weight_for_so > 1 and product_uom_pound or product_uom_case
+
+    @api.one
+    @api.constrains('case', 'product_uom_qty')
+    def validate_ordered_qty(self):
+        product_uom_qty = self.case * self.product_id.weight_for_so
+        if self.case > 0 and self.product_uom_qty != product_uom_qty:
+            raise ValidationError(_('The calculated ordered quantity has been modified, if you need to recalculate the ordered quantity then you have to modify the Cases value'))
+
+    @api.depends('case', 'product_id', 'product_id.volume')
+    def _compute_volume(self):
+        for rec in self:
+            rec.volume = rec.case * rec.product_id.volume
+
+    @api.multi
+    def _prepare_invoice_line(self, qty):
+        self.ensure_one()
+        res = super(SaleOrderLine, self)._prepare_invoice_line(qty)
+        res['case'] = self.case
+        res['volume'] = self.volume
+        return res

--- a/ifscg_sale/views/invoice_views.xml
+++ b/ifscg_sale/views/invoice_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="invoice_form_inherit_ifscg" model="ir.ui.view">
+        <field name="name">invoice.form.view.inherit.ifscg</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_form"/>
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']//tree//field[@name='quantity']" position="before">
+                <field name="case" />
+            </xpath>
+            <xpath expr="//field[@name='invoice_line_ids']//tree//field[@name='quantity']" position="after">
+                <field name="volume" />
+            </xpath>
+        </field>
+    </record>
+    <record id="invoice_supplier_form_inherit_ifscg" model="ir.ui.view">
+        <field name="name">invoice.supplier.form.view.inherit.ifscg</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_supplier_form"/>
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']//tree//field[@name='quantity']" position="before">
+                <field name="case" />
+            </xpath>
+            <xpath expr="//field[@name='invoice_line_ids']//tree//field[@name='quantity']" position="after">
+                <field name="volume" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/ifscg_sale/views/product_views.xml
+++ b/ifscg_sale/views/product_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<odoo>
+
+    <record id="product_template_view_form_inherit_ifscg" model="ir.ui.view">
+        <field name="name">product.template.view.form.inherit.ifscg</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
+                <field name="weight_for_so"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/ifscg_sale/views/purchase_views.xml
+++ b/ifscg_sale/views/purchase_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_purchase_order_form_inherit_ifscg" model="ir.ui.view">
+        <field name="name">Purchase Order Form View Ifscg</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']//form//field[@name='product_qty']/.." position="before">
+                <label for="case" string="Case"/>
+                <div>
+                    <field name="case" class="oe_inline"/>
+                </div>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//field[@name='product_qty']/.." position="after">
+                <label for="volume" string="Volume"/>
+                <div>
+                    <field name="volume" class="oe_inline"/>
+                </div>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree//field[@name='product_qty']" position="before">
+                <field name="case" />
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree//field[@name='product_qty']" position="after">
+                <field name="volume" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/ifscg_sale/views/sale_views.xml
+++ b/ifscg_sale/views/sale_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_sale_order_form_inherit_ifscg" model="ir.ui.view">
+        <field name="name">sale.order.form.view.ifscg</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']//form//label[@for='product_uom_qty']" position="before">
+                <label for="case" string="Cases"/>
+                <div>
+                    <field name="case" class="oe_inline"/>
+                </div>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//label[@for='product_uom_qty']" position="after">
+                <label for="volume" string="Volume"/>
+                <div>
+                    <field name="volume" class="oe_inline"/>
+                </div>
+            </xpath>
+            <!-- <xpath expr="//field[@name='order_line']//form//field[@name='product_uom_qty']" position="attributes">
+                <attribute name="redonly">1</attribute>
+                <attribute name="forec_save">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree//field[@name='product_uom_qty']" position="attributes">
+                <attribute name="redonly">1</attribute>
+                <attribute name="forec_save">1</attribute>
+            </xpath> -->
+            <xpath expr="//field[@name='order_line']//tree//field[@name='product_uom_qty']" position="before">
+                <field name="case" />
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree//field[@name='product_uom_qty']" position="after">
+                <field name="volume" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
#Req 1:

- Create a new field "Weight for SO" on the product. (Default this to 1)
- Add a new column called cases on the SO Line.
- Ordered qty will be calculated by the formula (case * weight for SO)
- The SO line will have the new column and Ordered qty will be calculated based on that -

Since Case is 5, this gets multiplied by the weight which gets the ordered qty to 108.1.
If someone modifies the ordered qty, give a pop-up warning saying that "Adjust case qty as per ordered qty"

#Req 2:

Add a calculated field called "Volume" on the Invoice Form and PO Form.
Volume = Quantity (filed on invoice and PO) * volume (field on the product)

NEW SPEC AS PER [MAM]

* Move the field WEIGHT FOR SO from the Product/Sales tab to Product/Inventory tab at the Logistics area (Below weight and volume).
* The following should apply to Sales/Purchase/Transfers (Quotation(SO/PO)/Orders (SO/PO)/Invoices-Vendor Bills/Transfers):
  - At the line level, we should include the following columns:
Cases = Manual input by user
Ordered Qty = Cases * Weight for SO (From product template) *** Calculated field & Editable field as well
Volume = Volume (From product template) * Cases *** Calculated field (Note: The specs sent by Palak have a wrong formula for this value)
  - Warning message when the user tries to modify the calculated value at Ordered Qty, alert the client "The calculated ordered quantity has been modified, if you need to recalculate the ordered quantity then you have to modify the Cases value "

